### PR TITLE
修复输入带空格的字符

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,24 @@
 
 命令行版 ChatGPT 应用
 
-启动：
+## 设置环境变量
 
+```bash
+export OPENAI_API_KEY='你的KEY'
+```
+可添加到系统的 `.bashrc` 或 `.zshrc` 文件中
+
+
+## 启动
 ```bash
 go mod tidy
 go run chat.go
 ```
+
+
+# 安装到系统
+go build .
+mv chat-client /usr/local/bin/chatgpt
+
+
+

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ go run chat.go
 go build .
 mv chat-client /usr/local/bin/chatgpt
 ```
-
+终端输入chatgpt即可使用.
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ go run chat.go
 
 
 # 安装到系统
+```bash
 go build .
 mv chat-client /usr/local/bin/chatgpt
-
+```
 
 

--- a/chat.go
+++ b/chat.go
@@ -66,6 +66,14 @@ func main() {
 		}
 
 		if strings.HasSuffix(userInput, "\\c\n") {
+			// 数组还原
+			messages = []gpt3.ChatCompletionMessage{
+				{
+					Role:    "system",
+					Content: "你是ChatGPT, OpenAI训练的大型语言模型, 请尽可能简洁地回答我的问题",
+				},
+			}
+			fmt.Println("会话已重置")
 			continue
 		}
 
@@ -75,6 +83,25 @@ func main() {
 				Content: userInput,
 			},
 		)
+
+		if len(messages) > 4096 {
+			// 数组还原
+			messages = []gpt3.ChatCompletionMessage{
+				{
+					Role:    "system",
+					Content: "你是ChatGPT, OpenAI训练的大型语言模型, 请尽可能简洁地回答我的问题",
+				},
+			}
+			fmt.Println("会话已重置")
+
+			// 重新添加消息
+			messages = append(
+				messages, gpt3.ChatCompletionMessage{
+					Role:    "user",
+					Content: userInput,
+				},
+			)
+		}
 
 		// 调用 ChatGPT API 接口生成回答
 		resp, err := client.CreateChatCompletion(

--- a/chat.go
+++ b/chat.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/glamour"
 	"github.com/common-nighthawk/go-figure"
@@ -61,6 +62,10 @@ func main() {
 		}
 
 		if userInput == "" || userInput == "\n" {
+			continue
+		}
+
+		if strings.HasSuffix(userInput, "\\c\n") {
 			continue
 		}
 


### PR DESCRIPTION
1. 原有代码中的scanln会把字符串按空格拆分,分别去请求chatgpt, 这里做了修改.
2. 添加了图标头像提示, 区分自己和chatgpt的会话